### PR TITLE
FixBugIssues4

### DIFF
--- a/Assets/scripts/GameManager.cs
+++ b/Assets/scripts/GameManager.cs
@@ -33,6 +33,7 @@ public class GameManager : MonoBehaviour {
 	}
 
 	void OnEnable(){
+		CountdownText.OnCountdownFinished += OnCountdownFinished;
 		TapController.OnPlayerDied += OnPlayerDied;
 		TapController.OnPlayerScored += OnPlayerScored;
 	


### PR DESCRIPTION
Bug yang terjadi ketika game diplay dan countdown berjalan namun berhenti pada hitungan ke 1, kemudian untuk men track error dilakukan breakpoint pada script di bagian OnCountdownFinished() pada script CountdownText.cs melalui Unity Debugger di visual studio dan didapati value dari OnCountdownFinished() bernilai null sehingga terjadi error. Solving dilakukan dengan membuka code function dimana OnCountdownFinish() berada kemudian menambahkan CountdownText.OnCountdownFinished += OnCountdownFinished; agar dapat diassign di script lainnya