### PR TITLE
FixBugIssues5

### DIFF
--- a/Assets/scripts/GameManager.cs
+++ b/Assets/scripts/GameManager.cs
@@ -25,7 +25,7 @@ public class GameManager : MonoBehaviour {
 	int score = 0;
 	bool gameOver = true;
 
-	public bool GameOver { get { return !gameOver; } }
+	public bool GameOver { get { return gameOver; } }
 
 	void Awake(){
 	


### PR DESCRIPTION
Bug yang terjadi karena pada script GameManager.cs dibagian Getter variabel gameover yang diambil bernilai terbalik karena terdapat simbol ! yang merupakan negasi, sehingga ketika variabel gameover dipakai di fungsi bawahnya maka permainan yang harusnya berjalan malah berhenti karena nilai gameover(permainan berhenti) yang harusnya false malah menjadi true