### PR TITLE
FixBugIssues8

### DIFF
--- a/Assets/scripts/GameManager.cs
+++ b/Assets/scripts/GameManager.cs
@@ -57,7 +57,7 @@ public class GameManager : MonoBehaviour {
 	void OnPlayerDied(){
 		gameOver = true;
 		int savedScore = PlayerPrefs.GetInt ("highscore");
-		if (score < savedScore) {
+		if (score > savedScore) {
 			PlayerPrefs.SetInt ("highscore", score);
 		
 		}


### PR DESCRIPTION
Highscore yang tidak tersimpan karena pada script GameManager.cs di fungsi OnPlayerDied kondisi yang dituliskan ada kesalahan simbol if (score < savedScore) seharusnya menjadi if (score > savedScore)  karena highscore akan muncul ketika score terbaru lebih besar dari savedScore sebelumnya